### PR TITLE
Change args parameters

### DIFF
--- a/src/android/com/mikakrooswijk/mongodb/plugin/MongoDBStorage.java
+++ b/src/android/com/mikakrooswijk/mongodb/plugin/MongoDBStorage.java
@@ -42,7 +42,7 @@ public class MongoDBStorage extends CordovaPlugin {
     private DatabaseControl database = new DatabaseControl();
 
     @Override
-    public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) {
+    public boolean execute(String action, final JSONArray args, final CallbackContext callbackContext) {
 
         context = callbackContext;
         boolean result = true;


### PR DESCRIPTION
On cordova 6.3, the args parameters is not been recognized, instead of putting it as final. 